### PR TITLE
Fix empty attributes check in read_gff3

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: 4.2.2
+          r-version: 4.3.1
 
       - uses: r-lib/actions/setup-pandoc@v2
       

--- a/R/read_gff3.R
+++ b/R/read_gff3.R
@@ -184,7 +184,7 @@ tidy_attributes <- function(x, is_gff2=FALSE, keep_attr=FALSE, fix_augustus_cds=
 
   d <- map_df(str_split(x[[9]], "; *"), function(r){
     # handle missing comments
-    if(is.na(r) || str_length(r) == 0)
+    if(all(is.na(r) | str_length(r) == 0))
       return(tibble(.rows=1)) # make sure this df has at least 1 row!
 
     # ignore empty elements caused by trailing or duplicated ";"


### PR DESCRIPTION
The original check used vectorized conditions with || and inside if. This is potentially problematic and results in errors rather than warnings starting from R version 4.2.0
Fix #156

The updated version now checks, whether all elements are `NA` or empty. I assume this is also the desired behaviour, as previously a leading semicolon would have caused all attributes to be ignored.